### PR TITLE
Fix no reminder on recurring appointments #30

### DIFF
--- a/appointments_cog.py
+++ b/appointments_cog.py
@@ -62,6 +62,8 @@ class AppointmentsCog(commands.Cog):
 
                         if appointment["reminder"] > 0 and diff > 0:
                             answer += f"in {diff} Minuten fällig."
+                            if appointment["recurring"]:
+                                appointment["original_reminder"] = str(appointment["reminder"])
                             appointment["reminder"] = 0
                         else:
                             answer += f"jetzt fällig. :loudspeaker: "
@@ -95,7 +97,7 @@ class AppointmentsCog(commands.Cog):
                             await self.add_appointment(channel, channel_appointment["author_id"],
                                                        splitted_new_date_time_str[0],
                                                        splitted_new_date_time_str[1],
-                                                       str(channel_appointment["reminder"]),
+                                                       str(channel_appointment["original_reminder"]),
                                                        channel_appointment["title"],
                                                        str(channel_appointment["recurring"]))
                         channel_appointments.pop(key)


### PR DESCRIPTION
Minifix für #30. Der Reminder wurde beim reminden auf 0 gesetzt, damit dieser nur einmal ausgeführt wird, dieser Wert wurde dann für einen Wiederholungstermin übernommen. Der Fix merkt sich nun den original Reminder und setzt diesen bei der Wiederholung wieder ein.