### PR TITLE
Fügt ein !calmdown Kommando hinzu welches Benutzer auf die stille Treppe schickt

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -33,6 +33,7 @@ DISCORD_LEARNINGGROUPS_REQUEST=<ID of Channel category for learning group reques
 DISCORD_LEARNINGGROUPS_INFO=<ID of Channel category for open learning groups>
 DISCORD_IDEE_CHANNEL=<ID of Channel, where bot ideas can be submitted>
 DISCORD_IDEE_EMOJI=<ID of Idee Emoji, used for reactions>
+DISCORD_CALMDOWN_ROLE=<ID of "Stille Treppe" role>
 
 # JSON Files
 DISCORD_ROLES_FILE=<File name for roles JSON file>
@@ -42,11 +43,8 @@ DISCORD_APPOINTMENTS_FILE=<File name for appointments JSON file>
 DISCORD_TEXT_COMMANDS_FILE=<File name for text commands JSON file>
 DISCORD_LEARNINGGROUPS_FILE=<File name for learning groups JSON file>
 DISCORD_LEARNINGGROUPS_COURSE_FILE=<File name for leaarning groups courses JSON file>
+DISCORD_CALMDOWN_FILE=<File name for calmdowns>
 
 # Misc
 DISCORD_DATE_TIME_FORMAT=<Date and time format used for commands like %d.%m.%Y %H:%M>
 DISCORD_IDEE_REACT_QTY=<Amount of reactions to a submitted idea, neccessary to create a github issue (amount is including botys own reaction)>
-
-
-
-

--- a/appointments_cog.py
+++ b/appointments_cog.py
@@ -6,25 +6,12 @@ import re
 
 import discord
 from discord.ext import tasks, commands
+
+import utils
 from help.help import help, handle_error, help_category
 
 
-def is_valid_time(time):
-    return re.match(r"^\d+[mhd]?$", time)
 
-
-def to_minutes(time):
-    if time[-1:] == "m":
-        return int(time[:-1])
-    elif time[-1:] == "h":
-        h = int(time[:-1])
-        return h * 60
-    elif time[-1:] == "d":
-        d = int(time[:-1])
-        h = d * 24
-        return h * 60
-
-    return int(time)
 
 
 @help_category("appointments", "Appointments", "Mit Appointments kannst du Termine zu einem Kanal hinzufügen. "
@@ -137,18 +124,18 @@ class AppointmentsCog(commands.Cog):
             await channel.send("Fehler! Ungültiges Datums und/oder Zeit Format!")
             return
 
-        if not is_valid_time(reminder):
+        if not utils.is_valid_time(reminder):
             await channel.send("Fehler! Benachrichtigung in ungültigem Format!")
             return
         else:
-            reminder = to_minutes(reminder)
+            reminder = utils.to_minutes(reminder)
 
         if recurring:
-            if not is_valid_time(recurring):
+            if not utils.is_valid_time(recurring):
                 await channel.send("Fehler! Wiederholung in ungültigem Format!")
                 return
             else:
-                recurring = to_minutes(recurring)
+                recurring = utils.to_minutes(recurring)
 
         embed = discord.Embed(title="Neuer Termin hinzugefügt!",
                               description=f"Wenn du eine Benachrichtigung zum Beginn des Termins"

--- a/calmdown.py
+++ b/calmdown.py
@@ -81,7 +81,7 @@ class Calmdown(commands.Cog):
             guild = ctx.guild
             role = guild.get_role(self.role_id)
             if not role:
-                ctx.channel.send("Fehler! Rolle nicht vorhanden")
+                ctx.channel.send("Fehler! Rolle nicht vorhanden!")
                 return
             duration = utils.to_minutes(duration)
             if duration == 0:

--- a/calmdown.py
+++ b/calmdown.py
@@ -67,7 +67,8 @@ class Calmdown(commands.Cog):
             "user": "Mention des Users der eine Auszeit benötigt",
             "duration": "Länge der Auszeit (24h für 24 Stunden 7d für 7 Tage oder 10m oder 10 für 10 Minuten. 0 hebt die Sperre auf).",
         },
-        description="In der Zeit auf der stillen Treppe darf der User noch alle Kanäle lesen. Das Schreiben ist für ihn allerdings bis zum Ablauf der Zeit gesperrt."
+        description="In der Zeit auf der stillen Treppe darf der User noch alle Kanäle lesen. Das Schreiben ist für ihn allerdings bis zum Ablauf der Zeit gesperrt.",
+        mod=True
     )
     @commands.command(name="calmdown", aliases=["auszeit", "mute"])
     @commands.check(utils.is_mod)

--- a/calmdown.py
+++ b/calmdown.py
@@ -1,0 +1,100 @@
+import datetime
+import json
+import os
+import re
+
+import discord
+from discord.ext import commands, tasks
+
+import utils
+from help.help import help
+
+"""
+    DISCORD_CALMDOWN_ROLE - Die Rollen-ID der "Stille Treppe"-Rolle.
+    DISCORD_CALMDOWN_FILE - Datendatei. Wenn diese noch nicht existiert wird sie angelegt.
+    DISCORD_DATE_TIME_FORMAT - Datumsformat für die interne Speicherung.
+"""
+
+class Calmdown(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.role_id = int(os.getenv("DISCORD_CALMDOWN_ROLE"))
+        self.file = os.getenv("DISCORD_CALMDOWN_FILE")
+        self.fmt = os.getenv("DISCORD_DATE_TIME_FORMAT")
+        self.silenced_users = {}
+        self.load()
+        self.timer.start()
+
+
+    def load(self):
+        try:
+            file = open(self.file, mode='r')
+            self.silenced_users = json.load(file)
+        except FileNotFoundError:
+            pass
+
+    def save(self):
+        file = open(self.file, mode='w')
+        json.dump(self.silenced_users, file)
+
+    async def unsilence(self, user, guild):
+        role = guild.get_role(self.role_id)
+        await user.remove_roles(role)
+        if self.silenced_users.get(user.id):
+            del self.silenced_users[user.id]
+            self.save()
+
+    @tasks.loop(minutes=1)
+    async def timer(self):
+        now = datetime.datetime.now()
+        silenced_users = self.silenced_users.copy()
+        for user_id, data in silenced_users.items():
+            guild = await self.bot.fetch_guild(int(data['guild_id']))
+            user = await guild.fetch_member(int(user_id))
+            duration = data.get('duration')
+            if not duration:
+                return
+            till = datetime.datetime.strptime(duration, self.fmt)
+            if user and now >= till:
+                guild = await self.bot.fetch_guild(data['guild_id'])
+                await utils.send_dm(user, f"Du darfst die **stille Treppe** nun wieder verlassen.")
+                await self.unsilence(user, guild)
+
+    @help(
+        brief="Setzt einen User auf die stille Treppe.",
+        example="!calmdown @user 1d",
+        parameters={
+            "user": "Mention des Users der eine Auszeit benötigt",
+            "duration": "Länge der Auszeit (24h für 24 Stunden 7d für 7 Tage oder 10m oder 10 für 10 Minuten. 0 hebt die Sperre auf).",
+        },
+        description="In der Zeit auf der stillen Treppe darf der User noch alle Kanäle lesen. Das Schreiben ist für ihn allerdings bis zum Ablauf der Zeit gesperrt."
+    )
+    @commands.command(name="calmdown", aliases=["auszeit", "mute"])
+    @commands.check(utils.is_mod)
+    async def cmd_calmdown(self, ctx, user: discord.Member, duration):
+        if re.match(r"^[0-9]+$", duration):
+            duration = f"{duration}m"
+        if not utils.is_valid_time(duration):
+            await ctx.channel.send("Fehler! Wiederholung in ungültigem Format!")
+            return
+        else:
+            guild = ctx.guild
+            role = guild.get_role(self.role_id)
+            if not role:
+                ctx.channel.send("Fehler! Rolle nicht vorhanden")
+                return
+            duration = utils.to_minutes(duration)
+            if duration == 0:
+                await ctx.channel.send(f"{ctx.author.mention} hat {user.mention} von der **stillen Treppe** geholt.")
+                await self.unsilence(user, guild)
+                return
+            now = datetime.datetime.now()
+            till = now + datetime.timedelta(minutes=duration)
+            self.silenced_users[user.id] = {"duration": till.strftime(self.fmt), "guild_id": guild.id}
+            self.save()
+            await ctx.channel.send(f"{ctx.author.mention} hat {user.mention} auf die **stille Treppe** geschickt.")
+            await user.add_roles(role)
+            if duration < 300:
+                await utils.send_dm(user, f"Du wurdest für {duration} Minuten auf die **stille Treppe** verbannt. Du kannst weiterhin alle Kanäle lesen, aber erst nach Ablauf der Zeit wieder an Gesprächen teilnehmen.")
+            else:
+                await utils.send_dm(user, f"Du wurdest bis {till.strftime(self.fmt)} Uhr auf die **stille Treppe** verbannt. Du kannst weiterhin alle Kanäle lesen, aber erst nach Ablauf der Zeit wieder an Gesprächen teilnehmen.")

--- a/fernuni_bot.py
+++ b/fernuni_bot.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import discord
@@ -6,7 +5,6 @@ from discord.ext import commands
 from dotenv import load_dotenv
 
 # from welcome_cog import WelcomeCog
-import utils
 from appointments_cog import AppointmentsCog
 from armin import Armin
 from christmas_cog import ChristmasCog
@@ -22,6 +20,7 @@ from text_commands_cog import TextCommandsCog
 from voice_cog import VoiceCog
 from welcome_cog import WelcomeCog
 from help.help import Help
+from calmdown import Calmdown
 
 # .env file is necessary in the same directory, that contains several strings.
 load_dotenv()
@@ -53,6 +52,7 @@ bot.add_cog(EasterCog(bot))
 bot.add_cog(Armin(bot))
 bot.add_cog(LearningGroups(bot))
 bot.add_cog(Help(bot))
+bot.add_cog(Calmdown(bot))
 
 
 def get_reaction(reactions):

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import os
 
 import discord
-
+import re
 
 async def send_dm(user, message, embed=None):
     """ Send DM to a user/member """
@@ -22,3 +22,22 @@ def is_mod(ctx):
             return True
 
     return False
+
+
+def is_valid_time(time):
+    return re.match(r"^\d+[mhd]?$", time)
+
+
+def to_minutes(time):
+    if time[-1:] == "m":
+        return int(time[:-1])
+    elif time[-1:] == "h":
+        h = int(time[:-1])
+        return h * 60
+    elif time[-1:] == "d":
+        d = int(time[:-1])
+        h = d * 24
+        return h * 60
+
+    return int(time)
+


### PR DESCRIPTION
`!calmdown @user <time>` (oder alternativ `!mute`, `!auszeit`) gibt dem User die Rolle `Stille Treppe` (id über env konfigurierbar). Dieser Rolle sollten auf dem Server für alle Kanäle die Schreibrechte entzogen werden. Über diesen Mechanismus lässt sich einem Benutzer eine Zwangspause verordnen.