### PR TITLE
ViewManager for Elmstreet

### DIFF
--- a/cogs/elm_street.py
+++ b/cogs/elm_street.py
@@ -7,6 +7,8 @@ from disnake import ApplicationCommandInteraction, ButtonStyle
 from disnake.ext import commands
 from dotenv import load_dotenv
 
+from utils import send_dm
+
 load_dotenv()
 
 

--- a/fernuni_bot.py
+++ b/fernuni_bot.py
@@ -4,6 +4,7 @@ import disnake
 from disnake.ext import commands
 from dotenv import load_dotenv
 
+from view_manager import ViewManager
 from cogs import appointments, calmdown, christmas, easter, github, help, learninggroups, links, \
     news, polls, roles, support, text_commands, voice, welcome, xkcd, elm_street \
     # , timer
@@ -24,6 +25,7 @@ class Boty(commands.Bot):
     def __init__(self):
         super().__init__(command_prefix='!', help_command=None, activity=disnake.Game(ACTIVITY), owner_id=OWNER,
                          intents=disnake.Intents.all())
+        self.view_manager = ViewManager(self)
         self.add_cog(appointments.Appointments(self))
         self.add_cog(text_commands.TextCommands(self))
         self.add_cog(polls.Polls(self))
@@ -43,10 +45,12 @@ class Boty(commands.Bot):
         self.add_cog(github.Github(self))
         # self.add_cog(timer.Timer(self))
         self.add_cog(elm_street.ElmStreet(self))
-
     def is_prod(self):
         return os.getenv("DISCORD_PROD") == "True"
 
+    async def on_ready(self):
+        self.view_manager.on_ready()
+        print("Client started!")
 
 bot = Boty()
 
@@ -82,9 +86,9 @@ async def unpin_message(message):
             await message.unpin()
 
 
-@bot.event
-async def on_ready():
-    print("Client started!")
+# @bot.event
+# async def on_ready():
+#     print("Client started!")
 
 
 @bot.event

--- a/utils.py
+++ b/utils.py
@@ -43,24 +43,3 @@ def to_minutes(time):
         return h * 60
 
     return int(time)
-
-
-async def dialog(channel, title, description, message="", buttons=None, callback=None):
-    embed = disnake.Embed(title=title,
-                          description=description,
-                          color=19607)
-    return await channel.send(message, embed=embed, view=DialogView(buttons, callback))
-
-
-async def confirm(channel, title, description, message="", callback=None):
-    return await dialog(
-        channel=channel,
-        title=title,
-        description=description,
-        message=message,
-        callback=callback,
-        buttons=[
-            {"emoji": "👍", "value": True},
-            {"emoji": "👎", "value": False}
-        ]
-    )

--- a/view_manager.py
+++ b/view_manager.py
@@ -1,0 +1,77 @@
+import json
+import uuid
+
+import disnake
+
+from views.dialog_view import DialogView
+
+
+class ViewManager:
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.views = {}
+        self.functions = {}
+        self.load()
+
+    def on_ready(self):
+        for view_id in self.views:
+            view = self.build_view(view_id)
+            self.bot.add_view(view)
+
+    def save(self):
+        with open("data/views.json", "w") as file:
+            json.dump(self.views, file)
+
+    def load(self):
+        with open("data/views.json", "r") as file:
+            self.views = json.load(file)
+
+    def register(self, key, func):
+        self.functions[key] = func
+
+    async def confirm(self, channel, title, description, custom_prefix, message="", callback_key: str = None):
+        return await self.dialog(
+            channel=channel,
+            title=title,
+            description=description,
+            message=message,
+            callback_key=callback_key,
+            buttons=[
+                {"emoji": "👍", "custom_id": f"{custom_prefix}_confirm_yes", "value": True},
+                {"emoji": "👎", "custom_id": f"{custom_prefix}_confirm_no", "value": False}
+            ]
+        )
+
+    async def dialog(self, channel, title, description, message="", buttons=None, callback_key: str = None):
+        embed = disnake.Embed(title=title,
+                              description=description,
+                              color=19607)
+        return await channel.send(message, embed=embed, view=self.view(buttons, callback_key))
+
+    def view(self, buttons=None, callback_key: str = None):
+        if buttons is None:
+            buttons = []
+        view_id = str(uuid.uuid4())
+        self.prepare_buttons(buttons, view_id)
+        view_config = {"buttons": buttons, "callback_key": callback_key}
+        self.views[view_id] = view_config
+        self.save()
+        return self.build_view(view_id)
+
+    def build_view(self, view_id):
+        view_config = self.views[view_id]
+        callback_key = view_config["callback_key"]
+        func = self.functions[callback_key]
+        return DialogView(self.views[view_id]["buttons"], func)
+
+    def add_button(self, config):
+        pass
+
+    def prepare_buttons(self, buttons, view_id=None):
+        for config in buttons:
+            config["custom_id"] = config.get("custom_id", "") + ("" if not view_id else "_" + str(view_id))
+
+
+
+

--- a/views/dialog_view.py
+++ b/views/dialog_view.py
@@ -1,9 +1,12 @@
+import json
+import uuid
+
 import disnake
-from disnake import MessageInteraction, ButtonStyle
-from disnake.ui import Button
+from disnake import ButtonStyle
 
 
 class DialogView(disnake.ui.View):
+
     def __init__(self, buttons=None, callback=None):
         super().__init__(timeout=None)
         self.callback = callback


### PR DESCRIPTION
Buttons und Views werden vom ViewManager verwaltet.
**Wichtig**: Callbacks müssen in `on_ready` registriert werden. 
**Auch wichtig**: `custom_id` bei Buttons ist pflicht und `custom_prefix` beim aufruf von `confirm` auch (damit die Buttons nach dem Neustart gefunden werden können).

```py
self.bot.view_manager.register("on_join", self.on_join)
```
Der Key "on_join" wird dann beim erzeugen des Views bzw. beim Aufruf der `dialog` oder `confrim` Methode (beide nun im ViewMananger statt in util) als `callback_key` mit angegeben. So kann auch nach dem Neustart der richtige Callback wieder gefunden werden.
```py 
return self.bot.view_manager.view(buttons, "on_join")
```
```py
await self.bot.view_manager.confirm(thread, "Neuer Rekrut",
                                      f"{interaction.author.mention} würde sich gerne der Gruppe anschließen",
                                      custom_prefix="rekrut",
                                      callback_key="on_joined")
```