### PR TITLE
Stellenangebote der Uni posten

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,6 +40,7 @@ DISCORD_ELM_STREET_CHANNEL=<ID of elm street channel>
 DISCORD_HALLOWEEN_CATEGORY=<ID of Halloween category>
 DISCORD_SEASONAL_EVENTS_CATEGORY=<ID of Seasonal Events Category>
 DISCORD_ADVENT_CALENDAR_CHANNEL_2021=<ID of advent calendar chanel for 2021>
+DISCORD_JOBOFFERS_CHANNEL=<ID of stellenangebote Channel>
 
 # JSON Files
 DISCORD_ROLES_FILE=<File name for roles JSON file>
@@ -54,6 +55,7 @@ DISCORD_MODULE_COURSE_FILE=<File name for module course JSON file>
 DISCORD_MODULE_DATA_FILE=<File name for module data JSON file>
 DISCORD_TIMER_FILE=<File name for running timers JSON file>
 DISCORD_ADVENT_CALENDAR_FILE=<File name for advent calendar JSON file>
+DISCORD_JOBOFFERS_FILE=<File name for joboffers JSON file>
 
 # Misc
 DISCORD_DATE_TIME_FORMAT=<Date and time format used for commands like %d.%m.%Y %H:%M>

--- a/.env.template
+++ b/.env.template
@@ -62,4 +62,4 @@ DISCORD_DATE_TIME_FORMAT=<Date and time format used for commands like %d.%m.%Y %
 DISCORD_IDEE_REACT_QTY=<Amount of reactions to a submitted idea, neccessary to create a github issue (amount is including botys own reaction)>
 DISCORD_ADVENT_CALENDAR_START=<Start date and time for advent calendar. Something like "01.12.2021 00:00">
 DISCORD_JOBOFFERS_URL=<url from which joboffers are fetched, atm "https://www.fernuni-hagen.de/uniintern/arbeitsthemen/karriere/stellen/include/hk.shtml">
-DISCORD_JOBOFFERS_STD_FAK=<faculty for which joboffers should be postet, one of [mi|rewi|wiwi|ksw|psy]>
+DISCORD_JOBOFFERS_STD_FAK=<faculty for which joboffers should be postet, one of [mi|rewi|wiwi|ksw|psy|other|all]>

--- a/.env.template
+++ b/.env.template
@@ -61,3 +61,5 @@ DISCORD_JOBOFFERS_FILE=<File name for joboffers JSON file>
 DISCORD_DATE_TIME_FORMAT=<Date and time format used for commands like %d.%m.%Y %H:%M>
 DISCORD_IDEE_REACT_QTY=<Amount of reactions to a submitted idea, neccessary to create a github issue (amount is including botys own reaction)>
 DISCORD_ADVENT_CALENDAR_START=<Start date and time for advent calendar. Something like "01.12.2021 00:00">
+DISCORD_JOBOFFERS_URL=<url from which joboffers are fetched, atm "https://www.fernuni-hagen.de/uniintern/arbeitsthemen/karriere/stellen/include/hk.shtml">
+DISCORD_JOBOFFERS_STD_FAK=<faculty for which joboffers should be postet, one of [mi|rewi|wiwi|ksw|psy]>

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -64,6 +64,7 @@ class Joboffers(commands.Cog):
                             description="Liste Jobangebote der Uni auf")
     async def cmd_jobs(self, interaction: ApplicationCommandInteraction,
                        chosen_faculty: str = commands.Param(default=STD_FAK,
+                                                            name='faculty',
                                                             choices=['mi','rewi','wiwi','ksw','psy','other','all'])):
         await self.fetch_joboffers()
 
@@ -115,9 +116,11 @@ class Joboffers(commands.Cog):
                 deadline = detail_string[detail_string.index('[')+1:detail_string.index(']')]
                 link = job.find('a')['href']
 
-                # Umlaute aufräumen
-                info = info.replace("Ã¤","ä")
-                info = info.replace("Ã¼", "ü")
+                # Sonderzeichen aufräumen
+                to_replace = ["Ã¤", "Ã¼", "Â²", "â€ž", "â€œ"]
+                replace_with = ["ä", "ü", "²", "\"", "\""]
+                for i in range(len(to_replace)):
+                    info = info.replace(to_replace[i], replace_with[i])
 
                 faks = ["other", "wiwi", "mi", "ksw", "psy", "rewi"]
 

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -116,14 +116,20 @@ class Joboffers(commands.Cog):
 
     async def post_new_jobs(self, jobs):
         fak_text = "aller Fakultäten" if STD_FAK == 'all' else f"der Fakultät {STD_FAK}"
+        joboffers_channel = await self.bot.fetch_channel(self.joboffers_channel_id)
+
         embed = disnake.Embed(title="Neue Stellenangebote der Uni",
                               description=f"Ich habe folgende neue Stellenangebote {fak_text} gefunden:")
+        i = 0
         for job in jobs:
+            i += 1
             descr = f"{job['info']}\nDeadline: {job['deadline']}\n{job['link']}"
             embed.add_field(name=job['title'], value=descr, inline=False)
-
-        joboffers_channel = await self.bot.fetch_channel(self.joboffers_channel_id)
-        await joboffers_channel.send(embed=embed)
+            if i % 5 == 0:
+                await joboffers_channel.send(embed=embed)
+                embed = disnake.Embed(title="Neue Stellenangebote der Uni ... Fortsetzung")
+        if i % 5 != 0:
+            await joboffers_channel.send(embed=embed)
 
     async def fetch_joboffers(self):
         sess = aiohttp.ClientSession()

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -21,6 +21,8 @@ from cogs.help import help
   mit fak = [mi|rewi|wiwi|ksw|psy]
 """
 
+JOBS_URL = os.getenv("DISCORD_JOBOFFERS_URL")
+STD_FAK = os.getenv("DISCORD_JOBOFFERS_STD_FAK")
 
 class Joboffers(commands.Cog):
     def __init__(self, bot):
@@ -28,8 +30,6 @@ class Joboffers(commands.Cog):
         self.joboffers = {}
         self.joboffers_channel_id = int(os.getenv("DISCORD_JOBOFFERS_CHANNEL"))
         self.joboffers_file = os.getenv("DISCORD_JOBOFFERS_FILE")
-        self.jobs_url = os.getenv("DISCORD_JOBOFFERS_URL")
-        self.stad_fak = os.getenv("DISCORD_JOBOFFERS_STD_FAK")
         self.load_joboffers()
         self.update_loop.start()
 
@@ -53,9 +53,9 @@ class Joboffers(commands.Cog):
             self.joboffers = {}
 
     @help(
-        syntax="!jobs <fak?>",
+        syntax="/jobs <fak?>",
         parameters={
-            "fak": "*(optional)* Fakultät für die die studentische Hilfskraft Jobs ausgegeben werden sollen "
+            "fak": "Fakultät für die die studentische Hilfskraft Jobs ausgegeben werden sollen "
                    "(mi, rewi, wiwi, ksw, psy)"
         },
         brief="Ruft Jobangebote für Studiernde der Fernuni Hagen auf."
@@ -70,23 +70,22 @@ class Joboffers(commands.Cog):
                                                              disnake.OptionChoice('ksw','ksw'),
                                                              disnake.OptionChoice('psy','psy'),
                                                              disnake.OptionChoice('other','other')])])
-    async def cmd_jobs(self, interaction: ApplicationCommandInteraction, faculty: str):
+    async def cmd_jobs(self, interaction: ApplicationCommandInteraction, faculty: str = STD_FAK):
         await self.fetch_joboffers()
 
         embed = disnake.Embed(title="Stellenangebote der Uni",
                               description=f"Ich habe folgende Stellenangebote der Fakultät {faculty} gefunden:")
         if offers := self.joboffers.get(faculty):
-            for offer in offers:
-                offer = offers[offer]
-                descr = f"{offer['info']}\nDeadline: {offer['deadline']}\n{offer['link']}"
-                embed.add_field(name=offer['title'], value=descr, inline=False)
+            for offer_id, offer_data in self.joboffers.get(faculty).items():
+                descr = f"{offer_data['info']}\nDeadline: {offer_data['deadline']}\n{offer_data['link']}"
+                embed.add_field(name=offer_data['title'], value=descr, inline=False)
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
     async def post_new_jobs(self, jobs):
         embed = disnake.Embed(title="Neue Stellenangebote der Uni",
-                              description=f"Ich habe folgende neue Stellenangebote der Fakultät {self.stad_fak} gefunden:")
+                              description=f"Ich habe folgende neue Stellenangebote der Fakultät {STD_FAK} gefunden:")
         for job in jobs:
             descr = f"{job['info']}\nDeadline: {job['deadline']}\n{job['link']}"
             embed.add_field(name=job['title'], value=descr, inline=False)
@@ -97,7 +96,7 @@ class Joboffers(commands.Cog):
 
     async def fetch_joboffers(self):
         sess = aiohttp.ClientSession()
-        req = await sess.get(self.jobs_url)
+        req = await sess.get(JOBS_URL)
         text = await req.read()
         await sess.close()
 
@@ -136,18 +135,16 @@ class Joboffers(commands.Cog):
 
     async def check_for_new_jobs(self, old_joboffers):
         new_jobs = []
-        if fak := self.joboffers.get(self.stad_fak):
-            if fak_old := old_joboffers.get(self.stad_fak):
-                for offer_id in fak:
-                    offer = fak[offer_id]
+        if fak := self.joboffers.get(STD_FAK):
+            if fak_old := old_joboffers.get(STD_FAK):
+                for offer_id, offer_data in self.joboffers.get(STD_FAK).items():
                     if old_offer := fak_old.get(offer_id):
-                        if offer != old_offer:
-                            new_jobs.append(offer)
+                        if offer_data != old_offer:
+                            new_jobs.append(offer_data)
                     else:
-                        new_jobs.append(offer)
+                        new_jobs.append(offer_data)
             else:
-                for offer_id in fak:
-                    offer = fak[offer_id]
-                    new_jobs.append(offer)
+                for offer_id, offer_data in self.joboffers.get(STD_FAK).items():
+                    new_jobs.append(offer_data)
         if new_jobs:
             await self.post_new_jobs(new_jobs)

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -136,8 +136,9 @@ class Joboffers(commands.Cog):
 
         # alte Liste sichern zum Abgleich
         old_joboffers = deepcopy(self.joboffers)
+        # Liste leeren um outdated joboffers auszusortieren
+        self.joboffers = {}
 
-        # TODO: remove outdated jobs
         for job in list:
             detail_string = job.text.strip()
             if "Studentische Hilfskraft" in detail_string:

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -42,13 +42,13 @@ class Joboffers(commands.Cog):
         await self.bot.wait_until_ready()
 
     def save_joboffers(self):
-        joboffers_file = open(self.joboffers_file, mode='w')
-        json.dump(self.joboffers, joboffers_file)
+        with open(self.joboffers_file, mode='w') as joboffers_file:
+            json.dump(self.joboffers, joboffers_file)
 
     def load_joboffers(self):
         try:
-            joboffers_file = open(self.joboffers_file, mode='r')
-            self.joboffers = json.load(joboffers_file)
+            with open(self.joboffers_file, mode='r') as joboffers_file:
+                self.joboffers = json.load(joboffers_file)
         except FileNotFoundError:
             self.joboffers = {}
 
@@ -61,26 +61,19 @@ class Joboffers(commands.Cog):
         brief="Ruft Jobangebote für Studiernde der Fernuni Hagen auf."
     )
     @commands.slash_command(name="jobs", aliases=["offers","stellen","joboffers"],
-                            description="Liste Jobangebote der Uni auf",
-                            options=[disnake.Option(name="faculty",
-                                                    description="Fakultät",
-                                                    choices=[disnake.OptionChoice('mi','mi'),
-                                                             disnake.OptionChoice('rewi','rewi'),
-                                                             disnake.OptionChoice('wiwi','wiwi'),
-                                                             disnake.OptionChoice('ksw','ksw'),
-                                                             disnake.OptionChoice('psy','psy'),
-                                                             disnake.OptionChoice('other','other'),
-                                                             disnake.OptionChoice('all','all')])])
-    async def cmd_jobs(self, interaction: ApplicationCommandInteraction, faculty: str = STD_FAK):
+                            description="Liste Jobangebote der Uni auf")
+    async def cmd_jobs(self, interaction: ApplicationCommandInteraction,
+                       chosen_faculty: str = commands.Param(default=STD_FAK,
+                                                            choices=['mi','rewi','wiwi','ksw','psy','other','all'])):
         await self.fetch_joboffers()
 
-        fak_text = "aller Fakultäten" if faculty == 'all' else f"der Fakultät {faculty}"
+        fak_text = "aller Fakultäten" if chosen_faculty == 'all' else f"der Fakultät {chosen_faculty}"
 
         embed = disnake.Embed(title="Stellenangebote der Uni",
                               description=f"Ich habe folgende Stellenangebote {fak_text} gefunden:")
 
         for fak, fak_offers in self.joboffers.items():
-            if STD_FAK != 'all' and fak != faculty:
+            if chosen_faculty != 'all' and fak != chosen_faculty:
                 continue
             for offer_id, offer_data in fak_offers.items():
                 descr = f"{offer_data['info']}\nDeadline: {offer_data['deadline']}\n{offer_data['link']}"

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -1,0 +1,144 @@
+import json
+import os
+from copy import deepcopy
+
+import aiohttp
+from bs4 import BeautifulSoup
+import disnake
+from disnake.ext import commands, tasks
+from cogs.help import help, handle_error, help_category
+
+"""
+  Environment Variablen:
+  DISCORD_JOBOFFERS_FILE - json file mit allen aktuellen 
+  DISCORD_JOBOFFERS_CHANNEL - Channel-ID für Stellenangebote
+  
+  Struktur der json:
+  {fak:{id:{title:..., info:..., link:..., deadline:...}}
+  mit fak = [mi|rewi|wiwi|ksw|psy]
+"""
+
+JOBS_URL = "https://www.fernuni-hagen.de/uniintern/arbeitsthemen/karriere/stellen/include/hk.shtml"
+STD_FAK = "mi"
+
+
+class Joboffers(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.joboffers = {}
+        self.joboffers_channel_id = int(os.getenv("DISCORD_JOBOFFERS_CHANNEL"))
+        self.joboffers_file = os.getenv("DISCORD_JOBOFFERS_FILE")
+        self.load_joboffers()
+        self.update_loop.start()
+
+    @tasks.loop(hours=24)
+    async def update_loop(self):
+        await self.fetch_joboffers()
+
+    @update_loop.before_loop
+    async def before_update_loop(self):
+        await self.bot.wait_until_ready()
+
+    def save_joboffers(self):
+        joboffers_file = open(self.joboffers_file, mode='w')
+        json.dump(self.joboffers, joboffers_file)
+
+    def load_joboffers(self):
+        try:
+            joboffers_file = open(self.joboffers_file, mode='r')
+            self.joboffers = json.load(joboffers_file)
+        except FileNotFoundError:
+            self.joboffers = {}
+
+    @help(
+        syntax="!jobs <fak?>",
+        parameters={
+            "fak": "*(optional)* Fakultät für die die studentische Hilfskraft Jobs ausgegeben werden sollen "
+                   "(mi, rewi, wiwi, ksw, psy)"
+        },
+        brief="Ruft Jobangebote für Studiernde der Fernuni Hagen auf."
+    )
+    @commands.group(name="jobs", aliases=["offers","stellen","joboffers"], pass_context=True)
+    async def cmd_jobs(self, ctx, fak=None):
+        await self.fetch_joboffers()
+        if not fak:
+            fak = STD_FAK
+
+        embed = disnake.Embed(title="Stellenangebote der Uni",
+                              description=f"Ich habe folgende Stellenangebote der Fakultät {fak} gefunden:")
+        if offers := self.joboffers.get(fak):
+            for offer in offers:
+                offer = offers[offer]
+                descr = f"{offer['info']}\nDeadline: {offer['deadline']}\n{offer['link']}"
+                embed.add_field(name=offer['title'], value=descr, inline=False)
+
+        await ctx.channel.send(embed=embed)
+
+
+    async def post_new_jobs(self, jobs):
+        embed = disnake.Embed(title="Neue Stellenangebote der Uni",
+                              description=f"Ich habe folgende neue Stellenangebote der Fakultät {STD_FAK} gefunden:")
+        for job in jobs:
+            descr = f"{job['info']}\nDeadline: {job['deadline']}\n{job['link']}"
+            embed.add_field(name=job['title'], value=descr, inline=False)
+
+        joboffers_channel = await self.bot.fetch_channel(self.joboffers_channel_id)
+        await joboffers_channel.send(embed=embed)
+
+
+    async def fetch_joboffers(self):
+        sess = aiohttp.ClientSession()
+        req = await sess.get(JOBS_URL)
+        text = await req.read()
+        await sess.close()
+
+        soup = BeautifulSoup(text, "html.parser")
+        list = soup.findAll("li")
+
+        # alte Liste sichern zum Abgleich
+        old_joboffers = deepcopy(self.joboffers)
+
+        for job in list:
+            detail_string = job.text.strip()
+            if "Studentische Hilfskraft" in detail_string:
+                id = detail_string[detail_string.index('(')+12:detail_string.index(')')]
+                title = detail_string[:detail_string.index(')')+1]
+                info = detail_string[detail_string.index(')')+1:detail_string.index('[')]
+                deadline = detail_string[detail_string.index('[')+1:detail_string.index(']')]
+                link = job.find('a')['href']
+
+                # Umlaute aufräumen
+                info = info.replace("Ã¤","ä")
+                info = info.replace("Ã¼", "ü")
+
+                faks = ["other", "wiwi", "mi", "ksw", "psy", "rewi"]
+
+                fak_id = int(id[0]) # Kennziffer 1=wiwi, 2=mi, 3=ksw, 4=psy, 5=rewi, alle anderen=other
+                if fak_id in range(1,6):
+                    fak = faks[fak_id]
+                else:
+                    fak = faks[0]
+
+                if not self.joboffers.get(fak):
+                    self.joboffers[fak] = {}
+                self.joboffers[fak][id] = {'title': title, 'info': info, 'deadline': deadline, 'link': link}
+        self.save_joboffers()
+        await self.check_for_new_jobs(old_joboffers)
+
+    async def check_for_new_jobs(self, old_joboffers):
+        new_jobs = []
+        if fak := self.joboffers.get(STD_FAK):
+            if fak_old := old_joboffers.get(STD_FAK):
+                for offer_id in fak:
+                    offer = fak[offer_id]
+                    if old_offer := fak_old.get(offer_id):
+                        if offer != old_offer:
+                            new_jobs.append(offer)
+                    else:
+                        new_jobs.append(offer)
+            else:
+                for offer_id in fak:
+                    offer = fak[offer_id]
+                    new_jobs.append(offer)
+        if new_jobs:
+            await self.post_new_jobs(new_jobs)

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -18,7 +18,7 @@ from cogs.help import help
   
   Struktur der json:
   {fak:{id:{title:..., info:..., link:..., deadline:...}}
-  mit fak = [mi|rewi|wiwi|ksw|psy|other|all]
+  mit fak = [mi|rewi|wiwi|ksw|psy|other]
 """
 
 JOBS_URL = os.getenv("DISCORD_JOBOFFERS_URL")

--- a/cogs/job_offers.py
+++ b/cogs/job_offers.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import aiohttp
 from bs4 import BeautifulSoup
 import disnake
+from disnake import ApplicationCommandInteraction
 from disnake.ext import commands, tasks
 from cogs.help import help, handle_error, help_category
 
@@ -58,21 +59,28 @@ class Joboffers(commands.Cog):
         },
         brief="Ruft Jobangebote für Studiernde der Fernuni Hagen auf."
     )
-    @commands.group(name="jobs", aliases=["offers","stellen","joboffers"], pass_context=True)
-    async def cmd_jobs(self, ctx, fak=None):
+    @commands.slash_command(name="jobs", aliases=["offers","stellen","joboffers"],
+                            description="Liste Jobangebote der Uni auf",
+                            options=[disnake.Option(name="faculty",
+                                                    description="Fakultät",
+                                                    choices=[disnake.OptionChoice('mi','mi'),
+                                                             disnake.OptionChoice('rewi','rewi'),
+                                                             disnake.OptionChoice('wiwi','wiwi'),
+                                                             disnake.OptionChoice('ksw','ksw'),
+                                                             disnake.OptionChoice('psy','psy'),
+                                                             disnake.OptionChoice('other','other')])])
+    async def cmd_jobs(self, interaction: ApplicationCommandInteraction, faculty: str = STD_FAK):
         await self.fetch_joboffers()
-        if not fak:
-            fak = STD_FAK
 
         embed = disnake.Embed(title="Stellenangebote der Uni",
-                              description=f"Ich habe folgende Stellenangebote der Fakultät {fak} gefunden:")
-        if offers := self.joboffers.get(fak):
+                              description=f"Ich habe folgende Stellenangebote der Fakultät {faculty} gefunden:")
+        if offers := self.joboffers.get(faculty):
             for offer in offers:
                 offer = offers[offer]
                 descr = f"{offer['info']}\nDeadline: {offer['deadline']}\n{offer['link']}"
                 embed.add_field(name=offer['title'], value=descr, inline=False)
 
-        await ctx.channel.send(embed=embed)
+        await interaction.response.send_message(embed=embed)
 
 
     async def post_new_jobs(self, jobs):

--- a/fernuni_bot.py
+++ b/fernuni_bot.py
@@ -5,7 +5,7 @@ from disnake.ext import commands
 from dotenv import load_dotenv
 
 from cogs import appointments, calmdown, github, help, learninggroups, links, timer, \
-    news, polls, roles, support, text_commands, voice, welcome, xkcd, module_information
+    news, polls, roles, support, text_commands, voice, welcome, xkcd, module_information, job_offers
 from view_manager import ViewManager
 
 # .env file is necessary in the same directory, that contains several strings.
@@ -56,6 +56,7 @@ class Boty(commands.Bot):
         self.add_cog(calmdown.Calmdown(self))
         self.add_cog(github.Github(self))
         self.add_cog(timer.Timer(self))
+        self.add_cog(job_offers.Joboffers(self))
 
 
 bot = Boty()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.9.3
 certifi==2020.12.5
 cffi==1.14.5
 chardet==3.0.4
-disnake==2.2.2
+disnake==2.3.2
 emoji==1.2.0
 idna==2.10
 multidict==5.1.0

--- a/views/joboffers_view.py
+++ b/views/joboffers_view.py
@@ -1,0 +1,35 @@
+import disnake
+from disnake import MessageInteraction, ButtonStyle
+from disnake.ui import Button, View
+
+NEXT = "jobs:next"
+PREV = "jobs:prev"
+
+
+class JobOffersView(View):
+    def __init__(self, callback, list_of_pages, actual_page_nr, embed_description):
+        super().__init__(timeout=None)
+        self.callback = callback
+        self.list_of_pages = list_of_pages
+        self.actual_page_nr = actual_page_nr
+        self.embed_description = embed_description
+        if actual_page_nr == 1:
+            self.disable_prev()
+        if actual_page_nr == len(self.list_of_pages):
+            self.disable_next()
+
+    @disnake.ui.button(emoji="⬅", custom_id=PREV)
+    async def btn_prev(self, button: Button, interaction: MessageInteraction):
+        await self.callback(button, interaction, self.list_of_pages, self.actual_page_nr, self.embed_description)
+
+    @disnake.ui.button(emoji="➡", custom_id=NEXT)
+    async def btn_next(self, button: Button, interaction: MessageInteraction):
+        await self.callback(button, interaction, self.list_of_pages, self.actual_page_nr, self.embed_description)
+
+    def disable_prev(self):
+        prev_button = self.children[0]
+        prev_button.disabled = True
+
+    def disable_next(self):
+        next_button = self.children[1]
+        next_button.disabled = True


### PR DESCRIPTION
Alle Jobangebote (studentische Hilfskraft) einer Fakultät der Uni lassen sich mit ~~`!jobs <fakultät>`~~ `/jobs <fakultät>` auflisten. Standardmäßig (ohne Angabe der Fakultät werden die Angebote für MI ausgegeben. Das ließe sich für die anderen Server (wenn gewollt) einfach durch ändern von `STD_FAK="mi"` (Standard-Fakultät) zu rewi, wiwi, psy oder ksw abändern.

Zusätzlich überprüft Boty alle 24 Stunden die Jobangebote. Wenn neue in der eingestellten Standard-Fakultät auftauchen, informiert Boty darüber im stellenangebote-Channel.

closes #147 

![image](https://user-images.githubusercontent.com/74598487/153711782-7f7f13db-83d0-4137-981b-9e3bf0a0e830.png)
![image](https://user-images.githubusercontent.com/74598487/153711831-0bdaaa1d-30a3-43e3-84f9-171fdad338b6.png)

[edit: zu Slash-Command geändert]
