### PR TITLE
Release v1.1.1

### DIFF
--- a/cogs/learninggroups.py
+++ b/cogs/learninggroups.py
@@ -49,7 +49,7 @@ class LearningGroups(commands.Cog):
         self.bot = bot
         # ratelimit 2 in 10 minutes (305 * 2 = 610 = 10 minutes and 10 seconds)
         self.rename_ratelimit = 305
-        self.msg_max_len = 2000
+        self.msg_max_len = 1900
 
         self.categories = {
             GroupState.OPEN: os.getenv('DISCORD_LEARNINGGROUPS_OPEN'),

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -103,6 +103,8 @@ class Roles(commands.Cog):
         show: Sichtbar für alle?
         """
 
+        await interaction.response.defer(ephemeral=not show)
+
         guild = interaction.guild
         members = await guild.fetch_members().flatten()
         guild_roles = {role.name: role for role in interaction.guild.roles}
@@ -119,4 +121,4 @@ class Roles(commands.Cog):
                 embed.add_field(name=role.name,
                                 value=f'{num_members} {"Mitglieder" if num_members > 1 else "Mitglied"}', inline=False)
 
-        await interaction.send(embed=embed, ephemeral=not show)
+        await interaction.edit_original_message(embed=embed)

--- a/cogs/timer.py
+++ b/cogs/timer.py
@@ -171,7 +171,8 @@ class Timer(commands.Cog):
 
         return embed
 
-    @commands.slash_command(name="timer", description="Erstelle deine persönliche  Eieruhr")
+    @commands.slash_command(name="timer", description="Erstelle deine persönliche  Eieruhr",
+                            guild_ids=[int(os.getenv('DISCORD_GUILD'))])
     async def cmd_timer(self, interaction: ApplicationCommandInteraction, working_time: int = 25,
                         break_time: int = 5,
                         name: str = None):


### PR DESCRIPTION
# Fixes:
- /timer zum guild-only command machen
- Problem mit zu langen Nachrichten in der Liste der Lerngruppen behoben
- Problem behoben, wenn nicht rechtzeitig auf die Interaction des /stats Commands geantwortet wurde

# Zu aktualisierende Dateien
*keine*

# Release Prozedur
1. `git pull`
2. Dienst neustarten