### PR TITLE
fix for broken websites (info_source is None)

### DIFF
--- a/cogs/components/module_information/scraper.py
+++ b/cogs/components/module_information/scraper.py
@@ -84,6 +84,8 @@ class Scraper:
             info_source = soup.find(summary='Modulinformationen')
         except:
             return None
+        if info_source is None:
+            return None
 
         infos = {
             "ects": self.get_info(info_source, 'ECTS'),


### PR DESCRIPTION
Fixt Botys Module Informationen. Wenn die Fernuni eine Webseite kaputt gemacht hat, wird nun trotzdem weitergescannt.