### PR TITLE
Temporärer fix: Modulnummern nach Kursnummern finden

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,8 +41,10 @@ DISCORD_LEARNINGGROUPS_COURSE_FILE=<Name of the JSON file that contains the cour
 DISCORD_CALMDOWN_FILE=<File name for calmdowns JSON file>
 DISCORD_MODULE_COURSE_FILE=<File name for module course JSON file>
 DISCORD_MODULE_DATA_FILE=<File name for module data JSON file>
+DISCORD_MODULE_COURSE_MAPPING_FILE=<File name for module-course mapping file>
 DISCORD_TIMER_FILE=<File name for running timers JSON file>
 DISCORD_ADVENT_CALENDAR_FILE=<File name for advent calendar JSON file>
+
 
 # Misc
 DISCORD_DATE_TIME_FORMAT=<Date and time format used for commands like %d.%m.%Y %H:%M>

--- a/extensions/components/module_information/module_resolver.py
+++ b/extensions/components/module_information/module_resolver.py
@@ -23,7 +23,7 @@ class ModuleResolver(object):
             "name": "Differentialrechnung mit dem Abakus"
           },
           {
-            "courseId": "01981",
+            "courseId": "01982",
             "name": "Das sehr große Einmaleins"
           }
         ]

--- a/extensions/components/module_information/module_resolver.py
+++ b/extensions/components/module_information/module_resolver.py
@@ -1,0 +1,57 @@
+import json
+
+class ModuleResolver(object):
+    """
+    Resolves module numbers
+    """
+    def __init__(self, module_course_mapping_file: str):
+        self.module_course_mapping_file = module_course_mapping_file
+        self._module_numbers_by_course_number = {}
+        self.load_mapping()
+
+    """
+    Load mapping file. Can be used to refresh the mapping on an existing ModuleResolver instance. 
+    
+    The expected file format looks as such:
+    [
+      {
+        "moduleId": "69901",
+        "moduleName": "Angewandte Mathematik bei Stromausfall",
+        "courses": [
+          {
+            "courseId": "01981",
+            "name": "Differentialrechnung mit dem Abakus"
+          },
+          {
+            "courseId": "01981",
+            "name": "Das sehr große Einmaleins"
+          }
+        ]
+      },
+      {
+        "moduleId": "69902",
+        "moduleName": "Einführung in verteiltes Echtzeit-COBOL",
+        "courses": [
+          {
+            "courseId": "01991",
+            "name": "Einführung in verteiltes Echtzeit-COBOL"
+          }
+        ]
+      }
+    ]
+    """
+    def load_mapping(self) -> None:
+        with open(self.module_course_mapping_file, 'r') as loaded_mapping_file:
+            mapping_json = json.load(loaded_mapping_file)
+            for module in mapping_json:
+                for course in module['courses']:
+                    self._module_numbers_by_course_number.setdefault(course['courseId'], []).append(module['moduleId'])
+
+    """
+    Retrieves module ids for a course number
+    
+    :param int course_id: the course number
+    :return: list of module ids or empty list if no modules were found
+    """
+    def get_modules_for_course(self, course_number: str) -> list[str]:
+        return self._module_numbers_by_course_number.get(course_number, [])


### PR DESCRIPTION
Die Modulnummern werden aus einem mapping-file gelesen, welches aus den öffentlich verfügbaren information auf
der FUH-website zusammengestellt wurde.
[module_mapping.json](https://github.com/FU-Hagen-Discord/fernuni-bot/files/14594491/module_mapping.json)

Das Dateiformat ist auch noch einmal grob in der neuen `ModuleResolver`-Klasse dokumentiert.

Der Dateipfad wird aus der Umgebungsvariable `DISCORD_MODULE_COURSE_MAPPING_FILE` gelesen.

Man möge mir etwaige nicht-pythonismen verzeihen, ist eine Weile her, dass ich python angefasst habe.

Das hier sollte erstmal den bot wieder fixen, den resolver wird man vermutlich dann nicht mehr brauchen, wenn die channels umbenannt sind.
