### PR TITLE
Umformulierungen des Modul-Embeds

### DIFF
--- a/extensions/module_information.py
+++ b/extensions/module_information.py
@@ -245,9 +245,9 @@ class ModuleInformation(commands.Cog):
             desc += ', '.join(persons) + "\n"
 
         if (courses := data['page'].get('courses')) and len(courses) > 0:
-            desc += f"\nKurse: \n"
+            desc += f"\nModul in der VU: \n"
             for course in courses:
-                desc += f"[{course['number']} - {course['name']}]({course['url']})\n"
+                desc += f"[{course['name']}]({course['url']})\n"
 
         desc += self.stg_string_for_desc(module)
         return discord.Embed(title=f"Modul {data['title']}",


### PR DESCRIPTION
Seit der Abschaffung der Kursen zugunsten der Modulen gibt es ein paar Sachen, die verwirrend sind. 

Teil 1 von erstmal 1: 
- Umschreibung des Embed-Abschnitts mit dem Link zur VU
- Vom selben Abschnitt: Entfernung von `course['number']`