### PR TITLE
Allow bots to read private learning groups

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,7 @@ DISCORD_PROD=<True, if running in an productive environment, otherwise False>
 # IDs
 DISCORD_OWNER=<ID of Server owner>
 DISCORD_MOD_ROLE=<ID of Mod Role>
+DISCORD_BOT_ROLE=<ID der Bot-Rolle, die alle Bots tragen>
 DISCORD_CATEGORY_LERNGRUPPEN=<Channel category for learning group voice channels>
 DISCORD_WELCOME_CHANNEL=<ID of Welcome channel, where Welcome Message should be posted>
 DISCORD_WELCOME_MSG=<ID of Welcome message>

--- a/extensions/learninggroups.py
+++ b/extensions/learninggroups.py
@@ -784,7 +784,7 @@ class LearningGroups(commands.GroupCog, name="lg", description="Lerngruppenverwa
 
         if group_config["organizer_id"] == interaction.author.id:
             await interaction.edit_original_response(content=
-                                                     "Du kannst nicht aus deiner eigenen Lerngruppe flüchten. Gib erst die Verantwortung ab.")
+                                                     "Du kannst nicht aus deiner eigenen Lerngruppe flüchten. Gib erst die Verantwortung ab. Falls deine Kommilitonys und du den Kanal nicht mehr braucht, dann pinge bitte die Mods (mit `@Mod`) an, damit sie ihn archivieren :door:")
             return
 
         await self.remove_member_from_group(interaction.channel, interaction.user)

--- a/extensions/learninggroups.py
+++ b/extensions/learninggroups.py
@@ -24,6 +24,7 @@ import utils
   DISCORD_LEARNINGGROUPS_FILE - Name der Datei mit Verwaltungsdaten der Lerngruppen (minimaler Inhalt: {"requested": {},"groups": {}})
   DISCORD_LEARNINGGROUPS_COURSE_FILE - Name der Datei welche die Kursnamen für die Lerngruppen-Informationen enthält (minimaler Inhalt: {})
   DISCORD_MOD_ROLE - ID der Moderations-Rolle, die erweiterte Lerngruppen-Aktionen ausführen darf
+  DISCORD_BOT_ROLE - ID der Bot-Rolle, die private Lerngruppen sehen darf
 """
 
 LG_OPEN_SYMBOL = f'🌲'
@@ -70,6 +71,7 @@ class LearningGroups(commands.GroupCog, name="lg", description="Lerngruppenverwa
         self.header_file = os.getenv('DISCORD_LEARNINGGROUPS_COURSE_FILE')
         self.support_channel = os.getenv('DISCORD_SUPPORT_CHANNEL')
         self.mod_role = os.getenv("DISCORD_MOD_ROLE")
+        self.bot_role = os.getenv("DISCORD_BOT_ROLE")
         self.guild_id = os.getenv("DISCORD_GUILD")
         self.groups = {}  # organizer and learninggroup-member ids
         self.channels = {}  # complete channel configs
@@ -453,9 +455,11 @@ class LearningGroups(commands.GroupCog, name="lg", description="Lerngruppenverwa
         group_config = self.groups["groups"].get(str(channel.id))
         guild = await self.bot.fetch_guild(int(self.guild_id))
         mods = guild.get_role(int(self.mod_role))
+        bots = guild.get_role(int(self.bot_role))
 
         overwrites = {
             mods: discord.PermissionOverwrite(read_messages=True),
+            bots: discord.PermissionOverwrite(read_messages=True),
             guild.default_role: discord.PermissionOverwrite(read_messages=False)
         }
 

--- a/extensions/new_emoji.py
+++ b/extensions/new_emoji.py
@@ -1,0 +1,42 @@
+import os
+import random
+
+from discord import Emoji, Guild
+from discord.ext import commands
+
+"""
+  Umgebungsvariablen:
+  DISCORD_KAFFEEECKE_ID - Channel ID der Kaffeeecke
+  DISCORD_GUILD - Guild ID des Servers
+"""
+
+class New_emoji(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.kaffeeecke_id = os.getenv('DISCORD_KAFFEEECKE_ID')
+        self.guild_id = os.getenv('DISCORD_GUILD')
+
+    #Listener if new emoji is created
+    @commands.Cog.listener()
+    async def on_guild_emojis_update(guild: discord.Guild, before: Sequence[discord.Emoji], after: Sequence[discord.Emoji]) -> None:
+        if guild.id != self.guild_id:
+            return
+
+        #IDs of Emojis before and after
+        before_ids = {e.id for e in before}
+        after_ids  = {e.id for e in after}
+
+        #Get the emojis added and removed
+        added   = [e for e in after  if e.id not in before_ids]
+        removed = [e for e in before if e.id not in after_ids]
+
+        # Falls added nicht leer
+        if added:
+            await kaffeeecke = self.bot.fetch_channel(int(self.kaffeeecke_id))
+            for emoji in added:
+                await kaffeeecke.send(f"Es gibt ein neues Emoji :{emoji.mention}:)
+
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Welcome(bot))


### PR DESCRIPTION
- You have to add a env variable `DISCORD_BOT_ROLE` with the id of the bot role
- If a learning group is set to private, the bot group will get permission to read the channel (and therefore they are allowed to write messages in private channels)